### PR TITLE
fix: error for get accounts list and balance with too much account

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -467,9 +467,12 @@ async function getAccountsDetails(accounts, bankUrl) {
         `${bankUrl}/${accountDetailsUrl}/${accounts[idx].caData.category}`
       ).then($ => {
         $.body.forEach(element => {
-          accounts.find(
-            x => x.caData.contrat == element.idElementContrat
-          ).balance = helpers.getBalance(element, fields.countWithInterest)
+          if (element.idElementContrat === accounts[idx].caData.contrat) {
+            accounts[idx].balance = helpers.getBalance(
+              element,
+              fields.countWithInterest
+            )
+          }
         })
       })
     }


### PR DESCRIPTION
old code making error when have many account who can get details
(it's possible with people who have access by procuration too a lot of account)
and stop script with error without finish to get account list
then take this new lines instead of other lines

=======

French : 

Le code auparavant émet une erreur lorsque l'utilisateur a plusieurs comptes dispo dans le json des details et stoppe le script
Il est possible d'avoit un lot enorme de compte lorsqu'on a une procuration pour les enfants par exemple ...
Ces changements permettent de lire correctement le contenu et de ne pas bloqué le script